### PR TITLE
feat: 検証可能なシリアル番号を生成

### DIFF
--- a/app/api/coupons/route.tsx
+++ b/app/api/coupons/route.tsx
@@ -1,6 +1,7 @@
 import sha256 from 'crypto-js/sha256';
 import {kv} from "@vercel/kv";
 import {NextRequest, NextResponse} from "next/server";
+import luhn from "luhn-js";
 
 function hashSerialNumber(serialNumber: string, passCode: string) : string {
     return serialNumber + sha256(`${passCode}:${process.env.SALT}`);
@@ -8,7 +9,7 @@ function hashSerialNumber(serialNumber: string, passCode: string) : string {
 
 function generateId() {
     let key = '';
-    const length = 12;
+    const length = 11;
     const characters = '0123456789';
     const charactersLength = characters.length;
     let counter = 0;
@@ -16,6 +17,7 @@ function generateId() {
         key += characters.charAt(Math.floor(Math.random() * charactersLength));
         counter += 1;
     }
+    key = luhn.generate(key);
     return key;
 }
 

--- a/app/update/page.tsx
+++ b/app/update/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React from 'react';
 import { ChangeEvent, FormEvent, useState } from "react";
+import luhn from "luhn-js";
 import 'bootstrap/dist/css/bootstrap.min.css'
 
 export default function Update() {
@@ -31,8 +32,21 @@ export default function Update() {
 
         event.preventDefault()
 
+        const serialNumberStr= serialNumber.replace(/[^0-9]/g, '')
+
+        if(!luhn.isValid(serialNumberStr)) {
+            setUpdateMessage(<div className="card text-bg-danger">
+                <div className="card-body">
+                    正しいシリアル番号を入力してください
+                </div>
+            </div>)
+            setSubmitUpdateDisabled(false)
+            return
+        }
+
         const formData = new FormData(event.currentTarget)
-        formData.set("serialNumber", serialNumber.replace(/[^0-9]/g, ''))
+        formData.set("serialNumber", serialNumberStr)
+
         const response = await fetch('/api/coupons', {
             method: 'PUT',
             body: JSON.stringify(Object.fromEntries(formData)),

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "crypto-js": "^4.2.0",
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
+    "luhn-js": "^1.1.2",
     "next": "13.4.13",
     "postcss": "8.4.22",
     "react": "18.2.0",


### PR DESCRIPTION
## 作業内容
- シリアル番号の末尾1桁をチェックディジットとし、リクエスト前に検証を行えるようにした

## スクリーンショット
※シリアル番号例：`7243-7558-5580`
| 発行 | 利用<br/>❌️ 間違っている場合 | 利用<br/>✅️ 正しい場合 |
| ---- | ---- | ---- |
| <img width="200" src="https://github.com/LambdaTechJP/katatataki-bank/assets/74450836/23aae7ac-3580-4896-aa0a-e47131bcc008"> | <img width="200" src="https://github.com/LambdaTechJP/katatataki-bank/assets/74450836/8fd8571f-17ba-439a-be68-e021819c9a82"> | <img width="200" src="https://github.com/LambdaTechJP/katatataki-bank/assets/74450836/635967fd-b21b-4444-9ccc-4517050c5320"> |

## 補足事項
- 一般的に使用されている [Luhnアルゴリズム](https://ja.wikipedia.org/wiki/Luhn%E3%82%A2%E3%83%AB%E3%82%B4%E3%83%AA%E3%82%BA%E3%83%A0) を採用しています（[luhn-js](https://yarnpkg.com/package?name=luhn-js) ライブラリを使用）
- 早期returnで書いているため、シリアル番号が間違っている場合は `/api/coupons` APIへのリクエストは行いません
